### PR TITLE
fixed CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,4 +59,4 @@ COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 WORKDIR /stdfile/logs
-CMD ["standardfile", "'-db /stdfile/db/sf.db'"]
+CMD ["standardfile","-db","/stdfile/db/sf.db"]


### PR DESCRIPTION
The CMD entry in the Dockerfile was improper. This causes the sf.db to be stored in /stdfile/logs rather than /stdfile/db.